### PR TITLE
Use awk over gawk to increase portability.

### DIFF
--- a/build/amuse.gnu
+++ b/build/amuse.gnu
@@ -15,7 +15,7 @@ LD = $(MPIFC)
 CC = $(MPIFC)
 Cp = /bin/cp
 Cpp = cpp -P
-AWK = /usr/bin/gawk
+AWK = /usr/bin/awk
 ABI = 
 COMMDIR = mpi
  

--- a/build/linuxDAS4.gnu
+++ b/build/linuxDAS4.gnu
@@ -15,7 +15,7 @@ LD = /cm/shared/apps/openmpi/intel/64/1.4.4/bin/mpif90 -lcurl
 CC = /cm/shared/apps/openmpi/intel/64/1.4.4/bin/mpicc 
 Cp = /bin/cp
 Cpp = cpp -P
-AWK = /usr/bin/gawk
+AWK = /usr/bin/awk
 ABI = 
 COMMDIR = mpi
  

--- a/build/linuxabsoft_serial.gnu
+++ b/build/linuxabsoft_serial.gnu
@@ -14,7 +14,7 @@ LD = f95
 CC = cc
 Cp = /bin/cp
 Cpp = /lib/cpp -P
-AWK = /usr/bin/gawk
+AWK = /usr/bin/awk
 ABI = 
 COMMDIR = serial
  

--- a/build/linuxg95_mpi.gnu
+++ b/build/linuxg95_mpi.gnu
@@ -13,7 +13,7 @@ LD = mpif90
 CC = cc
 Cp = /bin/cp
 Cpp = cpp -P
-AWK = /usr/bin/gawk
+AWK = /usr/bin/awk
 ABI = 
 COMMDIR = mpi
  

--- a/build/linuxg95_mpi_noswap.gnu
+++ b/build/linuxg95_mpi_noswap.gnu
@@ -13,7 +13,7 @@ LD = mpif90
 CC = cc
 Cp = /bin/cp
 Cpp = cpp -P
-AWK = /usr/bin/gawk
+AWK = /usr/bin/awk
 ABI = 
 COMMDIR = mpi
  

--- a/build/linuxg95_mpi_omp.gnu
+++ b/build/linuxg95_mpi_omp.gnu
@@ -13,7 +13,7 @@ LD = mpif90
 CC = cc
 Cp = /bin/cp
 Cpp = cpp -P
-AWK = /usr/bin/gawk
+AWK = /usr/bin/awk
 ABI = 
 COMMDIR = mpi
  

--- a/build/linuxg95_serial.gnu
+++ b/build/linuxg95_serial.gnu
@@ -14,7 +14,7 @@ LD = g95
 CC = cc
 Cp = /bin/cp
 Cpp = /lib/cpp -P
-AWK = /usr/bin/gawk
+AWK = /usr/bin/awk
 ABI = 
 COMMDIR = serial
  

--- a/build/linuxintel_mpi.gnu
+++ b/build/linuxintel_mpi.gnu
@@ -13,7 +13,7 @@ LD = ifort
 CC = cc
 Cp = /bin/cp
 Cpp = cpp -P
-AWK = /usr/bin/gawk
+AWK = /usr/bin/awk
 ABI = 
 COMMDIR = mpi
  

--- a/build/linuxintel_serial.gnu
+++ b/build/linuxintel_serial.gnu
@@ -13,7 +13,7 @@ LD = ifort
 CC = cc
 Cp = /bin/cp
 Cpp = cpp -P
-AWK = /usr/bin/gawk
+AWK = /usr/bin/awk
 ABI = 
 COMMDIR = serial
  

--- a/build/linuxintelbigendian_mpi.gnu
+++ b/build/linuxintelbigendian_mpi.gnu
@@ -13,7 +13,7 @@ LD = ifort
 CC = cc
 Cp = /bin/cp
 Cpp = cpp -P -C 
-AWK = /usr/bin/gawk
+AWK = /usr/bin/awk
 ABI = 
 COMMDIR = mpi
  

--- a/build/sgialtix_mpi.gnu
+++ b/build/sgialtix_mpi.gnu
@@ -13,7 +13,7 @@ LD = ifort
 CC = cc
 Cp = /bin/cp
 Cpp = cpp -P
-AWK = /usr/bin/gawk
+AWK = /usr/bin/awk
 ABI = 
 COMMDIR = mpi
  

--- a/build/sgialtix_serial.gnu
+++ b/build/sgialtix_serial.gnu
@@ -13,7 +13,7 @@ LD = ifort
 CC = cc
 Cp = /bin/cp
 Cpp = cpp -P
-AWK = /usr/bin/gawk
+AWK = /usr/bin/awk
 ABI = 
 COMMDIR = serial
  


### PR DESCRIPTION
Use awk over gawk to increase portability. The former is more likely available, where gawk available, it is typically symlinked with the same binary + it does not appear GNU awk is a prerequisite.
Fixes issue #1.
